### PR TITLE
Support for labeled category paths

### DIFF
--- a/src/LabeledCategoryPath.php
+++ b/src/LabeledCategoryPath.php
@@ -1,0 +1,64 @@
+<?php
+namespace SnowIO\Akeneo3DataModel;
+
+class LabeledCategoryPath
+{
+    public static function fromJson(array $labelCategoryPath): self
+    {
+        $result = new self;
+        $result->path = $labelCategoryPath;
+        return $result;
+    }
+
+    public function getCategoryLabel(): string
+    {
+        $level = $this->getLevel();
+        return $this->path[$level - 1];
+    }
+
+    public function getRootCategoryLabel(): string
+    {
+        return $this->path[0];
+    }
+
+    public function getParentCategoryLabel(): ?string
+    {
+        $level = $this->getLevel();
+        if ($level == 1) {
+            return null;
+        }
+        return $this->path[$level - 2];
+    }
+
+    public function getLevel(): int
+    {
+        return \count($this->path);
+    }
+
+    public function toArray(): array
+    {
+        return $this->path;
+    }
+
+    public function contains(string $categoryLabel): bool
+    {
+        foreach ($this->path as $ancestor) {
+            if ($categoryLabel === $ancestor) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function equals($other)
+    {
+        return $other instanceof self && $other->path === $this->path;
+    }
+
+    private $path = [];
+
+    private function __construct()
+    {
+
+    }
+}

--- a/src/LabeledCategoryPathSet.php
+++ b/src/LabeledCategoryPathSet.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace SnowIO\Akeneo3DataModel;
+
+use Traversable;
+
+final class LabeledCategoryPathSet implements \IteratorAggregate
+{
+    public static function fromJson(array $localization): self
+    {
+        $result = new self([]);
+        foreach ($localization as $locale => $localizationData) {
+            if (isset($localizationData['category_labels'])) {
+                $result->items[$locale] = LabeledCategoryPath::fromJson($localizationData["category_labels"]);
+            }
+        }
+        return $result;
+    }
+
+    public function getIterator(): \Iterator
+    {
+        foreach ($this->items as $locale => $item) {
+            yield $locale => $item;
+        }
+    }
+
+    public function fromLocale(string $locale): ?LabeledCategoryPath
+    {
+        return $this->items[$locale] ?? null;
+    }
+
+    /** @var array LabeledCategoryPaths */
+    private $items = [];
+
+    private function __construct(array $labeledCategoryPaths)
+    {
+        $this->items = $labeledCategoryPaths;
+    }
+}

--- a/src/ProductModelProperties.php
+++ b/src/ProductModelProperties.php
@@ -10,8 +10,14 @@ class ProductModelProperties
         $properties->code = $json['code'];
         $properties->familyVariant = FamilyVariantData::fromJson($json['family_variant']);
         $properties->categories = CategoryPathSet::fromJson($json['categories']);
+        $properties->categoryLabels = LabeledCategoryPathSet::fromJson($json['localizations']);
         $properties->parent = $json['parent'];
         return $properties;
+    }
+
+    public function getCategoryLabels(string $locale): ?LabeledCategoryPath
+    {
+        return $this->categoryLabels->fromLocale($locale);
     }
 
     public function getCategories(): CategoryPathSet
@@ -51,6 +57,8 @@ class ProductModelProperties
     private $labels;
     private $categories;
     private $parent;
+    /** @var LabeledCategoryPathSet */
+    private $categoryLabels;
 
     private function __construct()
     {

--- a/src/ProductProperties.php
+++ b/src/ProductProperties.php
@@ -27,8 +27,14 @@ class ProductProperties
         $properties->enabled = (bool)$json['enabled'];
         $properties->family = $json['family'];
         $properties->groups = $json['groups'];
+        $properties->categoryLabels = LabeledCategoryPathSet::fromJson($json['localizations']);
         $properties->categories = CategoryPathSet::fromJson($json['categories']);
         return $properties;
+    }
+
+    public function getCategoryLabels(string $locale): ?LabeledCategoryPath
+    {
+        return $this->categoryLabels->fromLocale($locale) ?? null;
     }
 
     public function getSku(): string
@@ -67,6 +73,8 @@ class ProductProperties
     private $enabled;
     private $family;
     private $categories;
+    /** @var LabeledCategoryPathSet */
+    private $categoryLabels;
 
     private function __construct()
     {

--- a/tests/LabeledCategoryPathSetTest.php
+++ b/tests/LabeledCategoryPathSetTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use SnowIO\Akeneo3DataModel\LabeledCategoryPath;
+use SnowIO\Akeneo3DataModel\LabeledCategoryPathSet;
+
+class LabeledCategoryPathSetTest extends TestCase
+{
+    /** @test */
+    public function shouldCreateAnObjectFromAnArray()
+    {
+        $categoryPathSet = LabeledCategoryPathSet::fromJson($this->getData());
+        /**
+         * @var int $index
+         * @var LabeledCategoryPath $categoryPath
+         */
+        foreach ($categoryPathSet as $index => $categoryPath) {
+            self::assertEquals($this->getData()[$index]["category_labels"], $categoryPath->toArray());
+        }
+    }
+
+    private function getData()
+    {
+        return [
+            "en_GB" => [
+                "category_labels" => [
+                    "Root",
+                    "Clothing",
+                    "Blouses"
+                ]
+            ],
+            "de_DE" => [
+                "category_labels" => [
+                    "Root",
+                    "Clothing",
+                    "Blouses"
+                ]
+            ],
+        ];
+    }
+}

--- a/tests/LabeledCategoryPathTest.php
+++ b/tests/LabeledCategoryPathTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use SnowIO\Akeneo3DataModel\LabeledCategoryPath;
+
+class LabeledCategoryPathTest extends TestCase
+{
+    /** @test */
+    public function shouldReturnTheLastLabelAsTheCategoryLabel()
+    {
+        $labeledCategoryPath = LabeledCategoryPath::fromJson(["A", "B", "C"]);
+        self::assertEquals("C", $labeledCategoryPath->getCategoryLabel());
+    }
+
+    /** @test */
+    public function shouldReturnTheFirstLabelAsTheRootCategoryLabel()
+    {
+        $labeledCategoryPath = LabeledCategoryPath::fromJson(["A", "B", "C"]);
+        self::assertEquals("A", $labeledCategoryPath->getRootCategoryLabel());
+    }
+
+    /** @test */
+    public function shouldReturnTheLastButOneAsTheParentCategoryLabel()
+    {
+        $labeledCategoryPath = LabeledCategoryPath::fromJson(["A", "B", "C"]);
+        self::assertEquals("B", $labeledCategoryPath->getParentCategoryLabel());
+    }
+
+    /** @test */
+    public function shouldReturnTheLevelAsTheNumberOfLabelsInTheLabeledCategoryPath()
+    {
+        $labeledCategoryPath = LabeledCategoryPath::fromJson(["A", "B", "C"]);
+        self::assertEquals(3, $labeledCategoryPath->getLevel());
+    }
+
+    /** @test */
+    public function shouldCheckTheContentsOfThePathCorrectly()
+    {
+        $labeledCategoryPath = LabeledCategoryPath::fromJson(["A", "B", "C"]);
+        self::assertTrue($labeledCategoryPath->contains("A"));
+        self::assertTrue($labeledCategoryPath->contains("B"));
+        self::assertFalse($labeledCategoryPath->contains("E"));
+    }
+
+    /** @test */
+    public function shouldCheckEqualityCorrectly()
+    {
+        $labeledCategoryPath = LabeledCategoryPath::fromJson(["A", "B", "C"]);
+        self::assertTrue($labeledCategoryPath->equals(
+            LabeledCategoryPath::fromJson(["A", "B", "C"])
+        ));
+
+        self::assertFalse(
+            $labeledCategoryPath->equals(
+                LabeledCategoryPath::fromJson(["A", "C", "B"])
+            )
+        );
+    }
+
+    /** @test */
+    public function shouldHaveACorrectArrayRepresentation()
+    {
+        $labeledCategoryPath = LabeledCategoryPath::fromJson($input = ["A", "B", "C"]);
+        self::assertEquals($input, $labeledCategoryPath->toArray());
+    }
+}

--- a/tests/ProductModelPropertiesTest.php
+++ b/tests/ProductModelPropertiesTest.php
@@ -4,6 +4,7 @@ use PHPUnit\Framework\TestCase;
 use SnowIO\Akeneo3DataModel\CategoryPath;
 use SnowIO\Akeneo3DataModel\FamilyVariantData;
 use SnowIO\Akeneo3DataModel\ProductModelProperties;
+use SnowIO\Akeneo3DataModel\Scope;
 
 class ProductModelPropertiesTest extends TestCase
 {
@@ -18,12 +19,23 @@ class ProductModelPropertiesTest extends TestCase
                 ['master_men_blazers']
             ],
             'family_variant' => FamilyVariantDataTest::getFamilyVariantData(),
-            'parent' => 'master_blazers'
+            'parent' => 'master_blazers',
+            'localizations' => [
+                'en_GB' => [
+                    "category_labels" => [
+                        [
+                            "Test Categories"
+                        ]
+                    ]
+                ]
+            ],
+
         ]);
 
         self::assertNotNull($productModelProperties->getCategories());
         self::assertNotNull($productModelProperties->getFamilyVariant());
         self::assertEquals('foo-bar', $productModelProperties->getCode());
+        self::assertNotNull($productModelProperties->getCategoryLabels("en_GB"));
         self::assertEquals('master_blazers', $productModelProperties->getParent());
     }
 }

--- a/tests/ProductPropertiesTest.php
+++ b/tests/ProductPropertiesTest.php
@@ -12,6 +12,7 @@ class ProductPropertiesTest extends TestCase
         $productProperties = ProductProperties::fromJson(self::getProductPropertiesAsJson());
         self::assertNotNull($productProperties->getCategories());
         self::assertEquals(true, $productProperties->getEnabled());
+        self::assertNotNull($productProperties->getCategoryLabels("en_GB"));
         self::assertEquals(["socks"], $productProperties->getGroups());
         self::assertEquals("main", $productProperties->getFamily());
         self::assertEquals("pm1234", $productProperties->getParent());
@@ -26,6 +27,16 @@ class ProductPropertiesTest extends TestCase
             "family" => "main",
             "groups" => ["socks"],
             "parent" => "pm1234",
+            'localizations' => [
+                'en_GB' => [
+                    "category_labels" => [
+                        [
+                            "Test Categories"
+                        ]
+                    ]
+                ],
+
+            ],
         ];
     }
 }


### PR DESCRIPTION
## Overview 

This PR aims to add support for labeled category paths. In order for it to be used in mappings where objects reference akeneo product and product model data.

## Tasks 
- [x] Update/Add test cases
- [x] Add implementation 