### PR TITLE
Enforce lower case attribute codes in akeneo data model

### DIFF
--- a/src/AttributeData.php
+++ b/src/AttributeData.php
@@ -47,7 +47,7 @@ class AttributeData
     public static function fromJson(array $json): self
     {
         $attribute = new self();
-        $attribute->code = $json['code'];
+        $attribute->code = strtolower($json['code']);
         $attribute->type = $json['type'];
         $attribute->localizable = (bool)$json['localizable'];
         $attribute->scopable = (bool)$json['scopable'];

--- a/src/AttributeOptionIdentifier.php
+++ b/src/AttributeOptionIdentifier.php
@@ -29,7 +29,7 @@ class AttributeOptionIdentifier
 
     private function __construct(string $attributeCode, string $optionCode)
     {
-        $this->attributeCode = $attributeCode;
+        $this->attributeCode = strtolower($attributeCode);
         $this->optionCode = $optionCode;
     }
 }

--- a/src/AttributeValueIdentifier.php
+++ b/src/AttributeValueIdentifier.php
@@ -33,7 +33,7 @@ class AttributeValueIdentifier
 
     private function __construct(string $attributeCode, Scope $scope)
     {
-        $this->attributeCode = $attributeCode;
+        $this->attributeCode = strtolower($attributeCode);
         $this->scope = $scope;
     }
 }

--- a/src/FamilyAttributeData.php
+++ b/src/FamilyAttributeData.php
@@ -27,7 +27,7 @@ class FamilyAttributeData
     public static function fromJson(array $json): self
     {
         $familyAttributeData = new self;
-        $familyAttributeData->code = $json['code'];
+        $familyAttributeData->code = strtolower($json['code']);
         $familyAttributeData->isRequired = $json['is_required'];
         $familyAttributeData->group = $json['group'];
         $familyAttributeData->sortOrder = $json['sort_order'];

--- a/tests/AttributeDataTest.php
+++ b/tests/AttributeDataTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use SnowIO\Akeneo3DataModel\AttributeData;
+use SnowIO\Akeneo3DataModel\InternationalizedString;
+
+class AttributeDataTest extends TestCase
+{
+
+    public function testFromJson()
+    {
+        $labels = ["en_GB" => "Diameter", "es_ES" => "Diametro"];
+        $attribute = AttributeData::fromJson(
+            [
+                "code" => "Diameter",
+                "type" => "pim_catalog_identifier",
+                "localizable" => 0,
+                "scopable" => 1,
+                "sort_order" => "10",
+                "labels" => $labels,
+                "group" => "default",
+            ]
+        );
+
+        self::assertEquals("diameter", $attribute->getCode());
+        self::assertEquals("pim_catalog_identifier", $attribute->getType());
+        self::assertTrue($attribute->getLabels()->equals(InternationalizedString::fromJson($labels)));
+        self::assertEquals("10", $attribute->getSortOrder());
+    }
+
+}

--- a/tests/AttributeOptionTest.php
+++ b/tests/AttributeOptionTest.php
@@ -13,7 +13,7 @@ class AttributeOptionTest extends TestCase
         $attributeOption = AttributeOption::fromJson(
             [
                 "code" => "size-110",
-                "attribute" => "size",
+                "attribute" => "Size",
                 "sort_order" => "67",
                 "labels" => $labels
             ]

--- a/tests/FamilyAttributeDataTest.php
+++ b/tests/FamilyAttributeDataTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use SnowIO\Akeneo3DataModel\FamilyAttributeData;
+use SnowIO\Akeneo3DataModel\InternationalizedString;
+
+class FamilyAttributeDataTest extends TestCase
+{
+
+    public function testFromJson()
+    {
+        $labels = ["en_GB" => "Diameter", "es_ES" => "Diametro"];
+        $attribute = FamilyAttributeData::fromJson(
+            [
+                "code" => "Diameter",
+                "is_required" => [
+                    "ecommerce" => true,
+                ],
+                "group" => "default",
+                "sort_order" => 10,
+            ]
+        );
+
+        self::assertEquals("diameter", $attribute->getCode());
+        self::assertEquals(true, $attribute->isRequired("ecommerce"));
+        self::assertEquals(10, $attribute->getSortOrder());
+    }
+
+}

--- a/tests/ProductDataTest.php
+++ b/tests/ProductDataTest.php
@@ -2,6 +2,8 @@
 
 use PHPUnit\Framework\TestCase;
 use SnowIO\Akeneo3DataModel\ProductData;
+use SnowIO\Akeneo3DataModel\AttributeValueIdentifier;
+use SnowIO\Akeneo3DataModel\Scope;
 
 class ProductDataTest extends TestCase
 {
@@ -13,6 +15,11 @@ class ProductDataTest extends TestCase
         self::assertEquals("foo", $productData->getSku());
         self::assertEquals(0, count(iterator_to_array($productData->getAttributeOptions()->getIterator())));
         self::assertNotNull($productData->getAttributeValues());
+
+        self::assertEquals(
+            "Red",
+            $productData->getAttributeValues()->getValue(AttributeValueIdentifier::of("colour", Scope::ofChannel("test")))
+        );
     }
 
     public static function getProductData()
@@ -28,6 +35,7 @@ class ProductDataTest extends TestCase
             "attribute_values" => [
                 "code" => "koppel_vase",
                 "brand" => null,
+                "Colour" => "Red",
                 "buying_member" => null,
                 "colour_group" => [],
                 "direct_delivery" => "0",


### PR DESCRIPTION
Other systems we typically integrate with don't allow for lowercase attribute codes, like Magento. Rather than enforcing this condition in Akeneo itself, we enforce it here in the data model as it's easier to maintain.

Clients should be discouraged from using lower case attribute codes anyway, and most of ours don't do this anyway, this is just a safe measure. 