### PR TITLE
Add decimals_allowed flag to attributedata

### DIFF
--- a/src/AttributeData.php
+++ b/src/AttributeData.php
@@ -43,6 +43,10 @@ class AttributeData
     {
         return $this->group;
     }
+    public function isDecimalsAllowed(): bool
+    {
+        return $this->decimalsAllowed;
+    }
 
     public static function fromJson(array $json): self
     {
@@ -54,6 +58,7 @@ class AttributeData
         $attribute->sortOrder = (int)$json['sort_order'];
         $attribute->labels = InternationalizedString::fromJson($json['labels']);
         $attribute->group = $json['group'];
+        $attribute->decimalsAllowed = (bool)($json['decimals_allowed'] ?? false);
         return $attribute;
     }
 
@@ -65,6 +70,7 @@ class AttributeData
     private $scopable;
     private $sortOrder;
     private $group;
+    private $decimalsAllowed;
 
     private function __construct()
     {

--- a/tests/AttributeDataTest.php
+++ b/tests/AttributeDataTest.php
@@ -19,6 +19,7 @@ class AttributeDataTest extends TestCase
                 "sort_order" => "10",
                 "labels" => $labels,
                 "group" => "default",
+                "decimals_allowed" => 1,
             ]
         );
 
@@ -26,6 +27,7 @@ class AttributeDataTest extends TestCase
         self::assertEquals("pim_catalog_identifier", $attribute->getType());
         self::assertTrue($attribute->getLabels()->equals(InternationalizedString::fromJson($labels)));
         self::assertEquals("10", $attribute->getSortOrder());
+        self::assertTrue($attribute->isDecimalsAllowed());
     }
 
 }


### PR DESCRIPTION
Used for number attributes, and useful to determine if attributes need to be created as int or float in downstream systems.